### PR TITLE
Spaceport integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 rfid-reader
-rfid-reader.exe
+RFID-Reader.exe
 build/

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,6 @@ require github.com/atotto/clipboard v0.1.4
 
 require (
 	github.com/akavel/rsrc v0.10.2 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 	"github.com/mattn/go-tty"
 	"github.com/micmonay/keybd_event"
 	"github.com/tarm/serial"
-  "math/rand"
+	"math/rand"
 	"net/http"
-  "net/url"
+	"net/url"
 	"os"
 	"runtime"
 	"time"
@@ -81,8 +81,8 @@ func main() {
 // dummySerial returns hardcoded serial bytes for local development and testing
 // Harded coded bytes are pushed into toAggregator channel
 func dummySerial(toAggregator chan<- byte, proceed chan<- bool) {
-  // set random seed for generating random numbers
-  rand.Seed(time.Now().UnixNano())
+	// set random seed for generating random numbers
+	rand.Seed(time.Now().UnixNano())
 
 	// the serial device wont fail, so we are good to proceed
 	proceed <- true
@@ -96,12 +96,12 @@ func dummySerial(toAggregator chan<- byte, proceed chan<- bool) {
 	// send simulated data forever
 	for {
 		for _, reading := range dummyReadings {
-      // simulate multiple scans to check debounce/deduplication behaviour
-      for i := 1; i < rand.Intn(8) + 1; i++ {
-        // send each byte from reading
-        for _, val := range reading {
-          toAggregator <- val
-        }
+			// simulate multiple scans to check debounce/deduplication behaviour
+			for i := 1; i < rand.Intn(8)+1; i++ {
+				// send each byte from reading
+				for _, val := range reading {
+					toAggregator <- val
+				}
 			}
 			// send a scan at regular intervals
 			time.Sleep(5 * time.Second)
@@ -180,26 +180,26 @@ func scanAggregatorDuplicator(fromSerial <-chan byte, bridges ...chan<- string) 
 // spaceportAPIBridge will POST scans to the spaceport API
 func spaceportAPIBridge(endpoint string, fromSerial <-chan string) {
 	var result string
-  var lastResult string
-  var lastResultTime time.Time
-  debounceTimeout, _ := time.ParseDuration("1s")
+	var lastResult string
+	var lastResultTime time.Time
+	debounceTimeout, _ := time.ParseDuration("1s")
 	for {
 		result = <-fromSerial
 
-    // TODO: DRY out debounce logic - perhaps into closure?
+		// TODO: DRY out debounce logic - perhaps into closure?
 		// debounce/deduplication
-    // if the current result is same as last
-    // AND the elapsed time is less then out timeout
-    // just skip it, we have the same reading in a short timeframe
-    if (result == lastResult && time.Since(lastResultTime) < debounceTimeout) {
-      continue
-    }
-    lastResult = result
-    lastResultTime = time.Now()
+		// if the current result is same as last
+		// AND the elapsed time is less then out timeout
+		// just skip it, we have the same reading in a short timeframe
+		if result == lastResult && time.Since(lastResultTime) < debounceTimeout {
+			continue
+		}
+		lastResult = result
+		lastResultTime = time.Now()
 
 		// set POST parameters
-    v := url.Values{}
-    v.Set("autoscan", result)
+		v := url.Values{}
+		v.Set("autoscan", result)
 
 		// POST to API
 		resp, err := http.PostForm(endpoint, v)

--- a/main.go
+++ b/main.go
@@ -3,14 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
-  "net/http"
 	"github.com/atotto/clipboard"
 	"github.com/mattn/go-tty"
 	"github.com/micmonay/keybd_event"
 	"github.com/tarm/serial"
+	"net/http"
 	"os"
 	"runtime"
-  "strings"
+	"strings"
 	"time"
 )
 
@@ -38,8 +38,8 @@ func main() {
 	flag.BoolVar(&testMode, "test", testMode, "Set test mode, which simulates a serial device instead of requiring connecting to a real one")
 	flag.Parse()
 
-  // set the endpoint based on environment
-  var endpoint string
+	// set the endpoint based on environment
+	var endpoint string
 	// set up a channel to transmit bytes from serial device to the "aggregator" function
 	scanPipe := make(chan byte)
 	// set up a channel to let main know if it is safe to continue or now
@@ -48,10 +48,10 @@ func main() {
 		fmt.Println("Test mode activated! Using a simulated device. Happy developing.")
 		fmt.Println("")
 		defaultDevice = "Test Simulator"
-    endpoint = DEV_ENDPOINT
+		endpoint = DEV_ENDPOINT
 		go dummySerial(scanPipe, proceedChan)
 	} else {
-    endpoint = PROD_ENDPOINT
+		endpoint = PROD_ENDPOINT
 		go openSerial(defaultDevice, defaultBaud, scanPipe, proceedChan)
 	}
 	if !<-proceedChan {
@@ -63,14 +63,14 @@ func main() {
 	}
 	fmt.Println("Successfully connected to serial device '" + defaultDevice + "'.")
 
-  // TODO: generalize: bridge w/ pipe so we can setup via config instead of hardcoding
-  // this might require making a factory for each bridge that returns the bridge function and a channel? factoring can accept configuration (e.g. endpoint for spaceport API, deduplication parameters, etc)
-  clipboardBridgePipe := make(chan string)
-  spaceportAPIBridgePipe := make(chan string)
-  go scanAggregatorDuplicator(scanPipe, clipboardBridgePipe, spaceportAPIBridgePipe)
+	// TODO: generalize: bridge w/ pipe so we can setup via config instead of hardcoding
+	// this might require making a factory for each bridge that returns the bridge function and a channel? factoring can accept configuration (e.g. endpoint for spaceport API, deduplication parameters, etc)
+	clipboardBridgePipe := make(chan string)
+	spaceportAPIBridgePipe := make(chan string)
+	go scanAggregatorDuplicator(scanPipe, clipboardBridgePipe, spaceportAPIBridgePipe)
 
 	go clipboardBridge(clipboardBridgePipe)
-  go spaceportAPIBridge(endpoint, spaceportAPIBridgePipe)
+	go spaceportAPIBridge(endpoint, spaceportAPIBridgePipe)
 	// keyboardBridge()
 
 	fmt.Println("Begin scanning!")
@@ -162,26 +162,26 @@ func scanAggregatorDuplicator(fromSerial <-chan byte, bridges ...chan<- string) 
 			}
 		}
 
-    // implement one-to-many - send result to each bridge
-    for _, bridge := range bridges {
-      bridge <- result
-    }
-  }
+		// implement one-to-many - send result to each bridge
+		for _, bridge := range bridges {
+			bridge <- result
+		}
+	}
 }
 
 // spaceportAPIBridge will POST scans to the spaceport API
 func spaceportAPIBridge(endpoint string, fromSerial <-chan string) {
-  var result string
-  for {
-    result = <-fromSerial
-    // TODO: debounce
+	var result string
+	for {
+		result = <-fromSerial
+		// TODO: debounce
 
-    // set POST parameters
-    content_type := "text/plain"
-    body := fmt.Sprintf("autoscan=%s", result)
+		// set POST parameters
+		content_type := "text/plain"
+		body := fmt.Sprintf("autoscan=%s", result)
 
-    // POST to API
-    resp, err := http.Post(endpoint, content_type, strings.NewReader(body))
+		// POST to API
+		resp, err := http.Post(endpoint, content_type, strings.NewReader(body))
 		if err != nil {
 			fail("Failed to sent to API: ", err)
 			return
@@ -192,14 +192,14 @@ func spaceportAPIBridge(endpoint string, fromSerial <-chan string) {
 
 // clipboardBridge will aggregate serial bytes into coherent records and send them to the users clipboard
 func clipboardBridge(fromSerial <-chan string) {
-  var result string
-  var err error
-  for {
-    result = <-fromSerial
+	var result string
+	var err error
+	for {
+		result = <-fromSerial
 		// opting not to implement debounce here
-    // because we overwrite the clipboard, multiple scans are idempotent
-    // debounce will make the console output nicer maybe
-    // but the functionality isn't improved
+		// because we overwrite the clipboard, multiple scans are idempotent
+		// debounce will make the console output nicer maybe
+		// but the functionality isn't improved
 
 		// copy the result to clipboard and notify user
 		// BUG: if you pass string([]byte) as result, clipboard.WriteAll will silently fail if []byte contains empty elements
@@ -321,7 +321,7 @@ var ascii_to_keydb_lookup = map[int]int{
 // keyboardBridge will simulate key presses
 func keyboardBridge() {
 	// TODO: Implement Keyboard bridge mode
-  panic("NOT IMPLEMENTED")
+	panic("NOT IMPLEMENTED")
 
 	kb, err := keybd_event.NewKeyBonding()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -54,7 +54,13 @@ func main() {
 	}
 	fmt.Println("Successfully connected to serial device '" + defaultDevice + "'.")
 
+  // TODO: generalize this
+  clipboardBridgePipe := make(chan string, 5)
+  scanAggregatorDuplicator(scanPipe, clipboardBridgePipe)
+
+  // TODO: pass clipboardBridgePipe instead of scanPipe
 	go clipboardBridge(scanPipe)
+  // TODO: implement and call spaceportAPIBridge in go routine
 	// TODO: Implement Keyboard bridge mode and allow user to select it instead of clipboard bridge
 	// pressKeys()
 
@@ -118,7 +124,18 @@ func openSerial(device string, baud int, toAggregator chan<- byte, proceed chan<
 	}
 }
 
-// clipboardBridge will aggregate serial bytes into coherent records and sending them to the users clipboard so that they may use it
+// scanAggregatorDuplicator will read from the serial device, aggregate results and multiply them to multiple channels
+func scanAggregatorDuplicator(fromSerial <-chan byte, bridges ...chan<- string) {
+  // pass off deduplication to bridge functions
+  // deduplication requirements are dictated by bridge implementations
+}
+
+// spaceportAPIBridge will POST scans to the spaceport API
+func spaceportAPIBridge(fromSerial <-chan byte) {
+
+}
+
+// clipboardBridge will aggregate serial bytes into coherent records and send them to the users clipboard
 func clipboardBridge(fromSerial <-chan byte) {
 	var result string
 	var err error

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var startCharacter = byte(10) // ASCII LF
 var endCharacter = byte(13)   // ASCII CR
 
 const DEV_ENDPOINT string = "https://api.spaceport.dns.t0.vc/stats/autoscan/"
-const PROD_ENDPOINT string = "https://my.protospace.ca/stats/autoscan/"
+const PROD_ENDPOINT string = "https://api.my.protospace.ca/stats/autoscan/"
 
 var timeout time.Duration
 

--- a/main.go
+++ b/main.go
@@ -55,10 +55,9 @@ func main() {
 	fmt.Println("Successfully connected to serial device '" + defaultDevice + "'.")
 
   // TODO: generalize: bridge w/ pipe so we can setup via config instead of hardcoding
-  clipboardBridgePipe := make(chan string, 5)
+  clipboardBridgePipe := make(chan string)
   go scanAggregatorDuplicator(scanPipe, clipboardBridgePipe)
 
-  // TODO: pass clipboardBridgePipe instead of scanPipe
 	go clipboardBridge(clipboardBridgePipe)
   // TODO: implement and call spaceportAPIBridge in go routine
 	// TODO: Implement Keyboard bridge mode and allow user to select it instead of clipboard bridge

--- a/main.go
+++ b/main.go
@@ -7,10 +7,11 @@ import (
 	"github.com/mattn/go-tty"
 	"github.com/micmonay/keybd_event"
 	"github.com/tarm/serial"
+  "math/rand"
 	"net/http"
+  "net/url"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 )
 
@@ -80,6 +81,9 @@ func main() {
 // dummySerial returns hardcoded serial bytes for local development and testing
 // Harded coded bytes are pushed into toAggregator channel
 func dummySerial(toAggregator chan<- byte, proceed chan<- bool) {
+  // set random seed for generating random numbers
+  rand.Seed(time.Now().UnixNano())
+
 	// the serial device wont fail, so we are good to proceed
 	proceed <- true
 
@@ -92,10 +96,14 @@ func dummySerial(toAggregator chan<- byte, proceed chan<- bool) {
 	// send simulated data forever
 	for {
 		for _, reading := range dummyReadings {
-			// send a scan at regular intervals
-			for _, val := range reading {
-				toAggregator <- val
+      // simulate multiple scans to check debounce/deduplication behaviour
+      for i := 1; i < rand.Intn(8) + 1; i++ {
+        // send each byte from reading
+        for _, val := range reading {
+          toAggregator <- val
+        }
 			}
+			// send a scan at regular intervals
 			time.Sleep(5 * time.Second)
 		}
 	}
@@ -172,21 +180,34 @@ func scanAggregatorDuplicator(fromSerial <-chan byte, bridges ...chan<- string) 
 // spaceportAPIBridge will POST scans to the spaceport API
 func spaceportAPIBridge(endpoint string, fromSerial <-chan string) {
 	var result string
+  var lastResult string
+  var lastResultTime time.Time
+  debounceTimeout, _ := time.ParseDuration("1s")
 	for {
 		result = <-fromSerial
-		// TODO: debounce
+
+    // TODO: DRY out debounce logic - perhaps into closure?
+		// debounce/deduplication
+    // if the current result is same as last
+    // AND the elapsed time is less then out timeout
+    // just skip it, we have the same reading in a short timeframe
+    if (result == lastResult && time.Since(lastResultTime) < debounceTimeout) {
+      continue
+    }
+    lastResult = result
+    lastResultTime = time.Now()
 
 		// set POST parameters
-		content_type := "text/plain"
-		body := fmt.Sprintf("autoscan=%s", result)
+    v := url.Values{}
+    v.Set("autoscan", result)
 
 		// POST to API
-		resp, err := http.Post(endpoint, content_type, strings.NewReader(body))
+		resp, err := http.PostForm(endpoint, v)
 		if err != nil {
 			fail("Failed to sent to API: ", err)
 			return
 		}
-		fmt.Println("Scan sent to Spaceport API: " + resp.Status)
+		fmt.Println("Scan sent to Spaceport API: " + result + " -> " + resp.Status)
 	}
 }
 


### PR DESCRIPTION
Hey dudes. In the spirit of upping organizational redundancy (and forcing Pat to have more fun with git :stuck_out_tongue:) figured I'd do a pull-request for this change. Don't feel any pressure to look at/review this - that won't hold anything up. PRs are just a nice way to get familiar with code in small bite sized chunks.

The thrust of this PR is to get `rfid-reader` `POST`'ing card scans to the spaceport API, which saves the directors the step of pasting it into the browser.

Side effects of this work:
- Fleshed out the "Serial-To-*" design a bit better. The bridges we have implemented are clipboard and spaceport API. Still haven't implemented keyboard, though it isn't super hard to do so. Happy to do it when there's a need for it, just haven't seen one yet.
- Added a debouncing/deduplication mechanism for card scans. This stops `rfid-reader` from spamming the API. Since it was easy, I added a debouncer to the clipboard bridge as well, which makes the console output a bit cleaner/less spammy

Because I am a savage, I hardcoded endpoints into the program. That means we need to maintain the DNS records for the API otherwise we will have to recompile (or better yet, provide endpoints via config) to `rfid-reader`